### PR TITLE
Fix CI workflow ensurepip failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-          cache: 'pip'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- revert the CI workflow to use `actions/setup-python@v4` so it no longer crashes while bootstrapping virtualenv on Python 3.11
- drop the pip cache configuration that triggered the failing `python -m venv` call

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb0478ff1883328b21ed472e95443c